### PR TITLE
Feature/homing commands

### DIFF
--- a/ws_thor/src/thor_controller/CMakeLists.txt
+++ b/ws_thor/src/thor_controller/CMakeLists.txt
@@ -46,7 +46,7 @@ install(
 )
 
 install(
-  DIRECTORY include
+  DIRECTORY include/thor_controller
   DESTINATION include
 )
 

--- a/ws_thor/src/thor_controller/include/thor_controller/thor_interface.hpp
+++ b/ws_thor/src/thor_controller/include/thor_controller/thor_interface.hpp
@@ -37,9 +37,6 @@ public:
   virtual hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
   virtual hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
-  // Function to send serial commands externally
-  static void enqueue_external_command(const std::string &cmd);
-
 
 private:
   LibSerial::SerialPort thor_;
@@ -51,12 +48,6 @@ private:
 
   bool homed_;
   std::string status_;
-
-  static std::queue<std::string>& get_external_command_queue();
-  static std::mutex& get_external_command_mutex();
-
-  static std::queue<std::string> external_command_queue_;
-  static std::mutex external_command_mutex_;
 };
 } // namespace thor_controller
 

--- a/ws_thor/src/thor_controller/include/thor_controller/thor_interface.hpp
+++ b/ws_thor/src/thor_controller/include/thor_controller/thor_interface.hpp
@@ -11,6 +11,9 @@
 #include <string>
 #include <nlohmann/json.hpp>
 
+#include <fstream>
+#include <sstream>
+
 namespace thor_controller
 {
 
@@ -34,6 +37,10 @@ public:
   virtual hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
   virtual hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
+  // Function to send serial commands externally
+  static void enqueue_external_command(const std::string &cmd);
+
+
 private:
   LibSerial::SerialPort thor_;
   std::string port_, board_type_;
@@ -44,6 +51,12 @@ private:
 
   bool homed_;
   std::string status_;
+
+  static std::queue<std::string>& get_external_command_queue();
+  static std::mutex& get_external_command_mutex();
+
+  static std::queue<std::string> external_command_queue_;
+  static std::mutex external_command_mutex_;
 };
 } // namespace thor_controller
 

--- a/ws_thor/src/thor_controller/src/thor_interface.cpp
+++ b/ws_thor/src/thor_controller/src/thor_interface.cpp
@@ -5,6 +5,18 @@
 namespace thor_controller
 {
 
+  std::queue<std::string>& ThorInterface::get_external_command_queue()
+  {
+      static std::queue<std::string> external_command_queue;
+      return external_command_queue;
+  }
+  
+  std::mutex& ThorInterface::get_external_command_mutex()
+  {
+      static std::mutex external_command_mutex;
+      return external_command_mutex;
+  }
+
 ThorInterface::ThorInterface()
 {
 }
@@ -19,6 +31,15 @@ ThorInterface::~ThorInterface()
       RCLCPP_FATAL_STREAM(rclcpp::get_logger("ThorInterface"), "Something went wrong while closing connection with port " << port_);
     }
   }
+}
+
+void ThorInterface::enqueue_external_command(const std::string &cmd)
+{
+    std::lock_guard<std::mutex> lock(get_external_command_mutex());
+    auto& queue = get_external_command_queue();
+    RCLCPP_INFO(rclcpp::get_logger("ThorInterface"), "Queue address: %p", static_cast<void*>(&queue));
+    queue.push(cmd);
+    RCLCPP_INFO(rclcpp::get_logger("ThorInterface"), "Command enqueued: %s", cmd.c_str());
 }
 
 CallbackReturn ThorInterface::on_init(const hardware_interface::HardwareInfo &hardware_info){
@@ -224,6 +245,21 @@ hardware_interface::return_type ThorInterface::read(const rclcpp::Time &time, co
     }
     catch(...){
       RCLCPP_ERROR(rclcpp::get_logger("ThorInterface"), "Failed to read data from Thor.");
+    }
+  }
+
+  // Process external commands
+  {
+    std::lock_guard<std::mutex> lock(get_external_command_mutex());
+    auto& queue = get_external_command_queue();
+    RCLCPP_INFO(rclcpp::get_logger("ThorInterface"), "Queue address: %p", static_cast<void*>(&queue));
+    RCLCPP_INFO(rclcpp::get_logger("ThorInterface"), "External command queue size: %zu", queue.size());
+    while (!queue.empty())
+    {
+        const std::string &cmd = queue.front();
+        RCLCPP_INFO(rclcpp::get_logger("ThorInterface"), "Sending external command: %s", cmd.c_str());
+        thor_.Write(cmd + "\r\n");
+        queue.pop();
     }
   }
 

--- a/ws_thor/src/thor_server/CMakeLists.txt
+++ b/ws_thor/src/thor_server/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(thor_controller REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/JointTask.action"
@@ -35,6 +36,10 @@ rclcpp_components_register_node(task_server
   EXECUTABLE task_server_node
 )
 
+add_executable(hardware_command_node src/hardware_command_node.cpp)
+ament_target_dependencies(hardware_command_node rclcpp std_msgs thor_controller)
+# target_link_libraries(hardware_command_node thor_controller)
+
 target_link_libraries(task_server "${cpp_typesupport_target}") 
 
 install(DIRECTORY action
@@ -43,6 +48,7 @@ install(DIRECTORY action
 
 install(TARGETS
     task_server
+    hardware_command_node
     DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ws_thor/src/thor_server/package.xml
+++ b/ws_thor/src/thor_server/package.xml
@@ -17,6 +17,7 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>std_msgs</depend>
   <depend>action_msgs</depend>
+  <depend>thor_controller</depend>
   
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/ws_thor/src/thor_server/src/hardware_command_node.cpp
+++ b/ws_thor/src/thor_server/src/hardware_command_node.cpp
@@ -1,0 +1,36 @@
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "thor_controller/thor_interface.hpp"
+
+using thor_controller::ThorInterface;
+
+class HardwareCommandNode : public rclcpp::Node
+{
+public:
+  HardwareCommandNode() : Node("hardware_command_node")
+  {
+    using std::placeholders::_1;
+    subscription_ = this->create_subscription<std_msgs::msg::String>(
+      "/hardware_command", 10,
+      std::bind(&HardwareCommandNode::command_callback, this, _1));
+
+    RCLCPP_INFO(this->get_logger(), "Nodo de comandos de hardware iniciado.");
+  }
+
+private:
+  void command_callback(const std_msgs::msg::String::SharedPtr msg)
+  {
+    RCLCPP_INFO(this->get_logger(), "Recibido comando: '%s'", msg->data.c_str());
+    ThorInterface::enqueue_external_command(msg->data);
+  }
+
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<HardwareCommandNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ws_thor/src/thor_server/src/hardware_command_node.cpp
+++ b/ws_thor/src/thor_server/src/hardware_command_node.cpp
@@ -1,8 +1,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
-#include "thor_controller/thor_interface.hpp"
-
-using thor_controller::ThorInterface;
+#include <fstream> // Para manejar archivos
 
 class HardwareCommandNode : public rclcpp::Node
 {
@@ -21,7 +19,16 @@ private:
   void command_callback(const std_msgs::msg::String::SharedPtr msg)
   {
     RCLCPP_INFO(this->get_logger(), "Recibido comando: '%s'", msg->data.c_str());
-    ThorInterface::enqueue_external_command(msg->data);
+
+    // Abrir el archivo en modo de agregar (append)
+    std::ofstream file("/tmp/commands.txt", std::ios::app);
+    if (file.is_open()) {
+      file << msg->data << "\n"; // Escribir el comando en una nueva línea
+      file.close();
+      RCLCPP_INFO(this->get_logger(), "Comando guardado en /tmp/commands.txt.");
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "No se pudo abrir /tmp/commands.txt para escribir.");
+    }
   }
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;


### PR DESCRIPTION
The hardware interface has been modified to allow processing of externally sent commands. A file located in /tmp has been used to enable this communication.
This is a dodge to get out of the way, since in commit[ cd76883](https://github.com/AngelLM/Thor-ROS/tree/cd76883a41b97fe45d0bca6e4e40eb33be97bf46) an attempt was made to perform this communication using a static variable as a queue, but it did not work.
If someone, at some point, finds a better solution, it would be nice to fix it.